### PR TITLE
Allow inclusion of exoquant.h in C++ source

### DIFF
--- a/exoquant.c
+++ b/exoquant.c
@@ -100,8 +100,8 @@ void exq_feed(exq_data *pExq, unsigned char *pData, int nPixels)
 		hash = exq_make_hash(((unsigned int)r) | (((unsigned int)g) << 8) | (((unsigned int)b) << 16) | (((unsigned int)a) << 24));
 
 		pCur = pExq->pHash[hash];
-		while(pCur != NULL && (pCur->or != r || pCur->og != g ||
-			pCur->ob != b || pCur->oa != a))
+		while(pCur != NULL && (pCur->ored != r || pCur->ogreen != g ||
+			pCur->oblue != b || pCur->oalpha != a))
 			pCur = pCur->pNextInHash;
 
 		if(pCur != NULL)
@@ -111,7 +111,7 @@ void exq_feed(exq_data *pExq, unsigned char *pData, int nPixels)
 			pCur = (exq_histogram*)malloc(sizeof(exq_histogram));
 			pCur->pNextInHash = pExq->pHash[hash];
 			pExq->pHash[hash] = pCur;
-			pCur->or = r; pCur->og = g; pCur->ob = b; pCur->oa = a;
+			pCur->ored = r; pCur->ogreen = g; pCur->oblue = b; pCur->oalpha = a;
 			r &= channelMask; g &= channelMask; b &= channelMask;
 			pCur->color.r = r / 255.0f * SCALE_R;
 			pCur->color.g = g / 255.0f * SCALE_G;
@@ -592,8 +592,8 @@ exq_histogram *exq_find_histogram(exq_data *pExq, unsigned char *pCol)
 	hash = exq_make_hash(((unsigned int)r) | (((unsigned int)g) << 8) | (((unsigned int)b) << 16) | (((unsigned int)a) << 24));
 
 	pCur = pExq->pHash[hash];
-	while(pCur != NULL && (pCur->or != r || pCur->og != g ||
-		pCur->ob != b || pCur->oa != a))
+	while(pCur != NULL && (pCur->ored != r || pCur->ogreen != g ||
+		pCur->oblue != b || pCur->oalpha != a))
 		pCur = pCur->pNextInHash;
 
 	return pCur;

--- a/exoquant.h
+++ b/exoquant.h
@@ -66,7 +66,7 @@ typedef struct _exq_color
 typedef struct _exq_histogram
 {
 	exq_color				color;
-	unsigned char			or, og, ob, oa;
+	unsigned char			ored, ogreen, oblue, oalpha;
 	int						palIndex;
 	exq_color				ditherScale;
 	int						ditherIndex[4];


### PR DESCRIPTION
Hi @DennisRanke, thanks for creating `exoquant`. I really like that does one thing well and fairly quickly too. Other image quantisation libraries I've looked at have dependencies on things like OpenCV or try to do too much with complex APIs.

I had to make this change to include the header file in a C++ source as `or` is a reserved keyword. The existing use of [`extern "C"`](https://github.com/exoticorn/exoquant/blob/master/exoquant.h#L54) doesn't seem to help this, at least with gcc.

I took the liberty of expanding the names of the other colour-related members of the `exq_histogram` struct for consistency and readability.

Cheers,
Lovell
